### PR TITLE
Test inline function calls, passing a volatile false argument

### DIFF
--- a/lib/inline_func_test.cpp
+++ b/lib/inline_func_test.cpp
@@ -26,7 +26,7 @@ namespace
 
 
 NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT
-double LIB_NAME::test_inline_func()
+double LIB_NAME::test_inline_func_literal_false()
 {
   enum { number_of_func_calls = NOEXCEPT_BENCHMARK_NUMBER_OF_INLINE_FUNC_CALLS };
 
@@ -37,4 +37,21 @@ double LIB_NAME::test_inline_func()
       inline_func(false);
     }
   });
+}
+
+
+NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT
+double LIB_NAME::test_inline_func_volatile_false()
+{
+  enum { number_of_func_calls = NOEXCEPT_BENCHMARK_NUMBER_OF_INLINE_FUNC_CALLS };
+
+  return noexcept_benchmark::profile_func_call([]
+    {
+      volatile bool volatile_false{ false };
+
+      for (int i = 0; i < number_of_func_calls; ++i)
+      {
+        inline_func(volatile_false);
+      }
+    });
 }

--- a/lib/lib.h
+++ b/lib/lib.h
@@ -49,7 +49,8 @@ namespace NOEXCEPT_BENCHMARK_LIB_NAME
   NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT void exported_func(bool do_throw_exception) NOEXCEPT_BENCHMARK_EXCEPTION_SPECIFIER;
   NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT double catching_func();
   NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT double test_inc_and_dec();
-  NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT double test_inline_func();
+  NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT double test_inline_func_literal_false();
+  NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT double test_inline_func_volatile_false();
   NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT double test_stack_unwinding();
   NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT double test_stack_unwinding_array();
   NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT double test_vector_reserve();

--- a/noexcept_benchmark_main.cpp
+++ b/noexcept_benchmark_main.cpp
@@ -246,13 +246,25 @@ int main()
     << std::endl;
   {
     test_result<NOEXCEPT_BENCHMARK_NUMBER_OF_INLINE_FUNC_CALLS> result(
-      "inline function calls");
+      "inline function calls, passing literal `false` as argument");
 
     for (int iteration_number = 0; iteration_number < number_of_iterations; ++iteration_number)
     {
       durations_type durations;
-      durations.duration_noexcept = noexcept_lib::test_inline_func();
-      durations.duration_implicit = implicit_lib::test_inline_func();
+      durations.duration_noexcept = noexcept_lib::test_inline_func_literal_false();
+      durations.duration_implicit = implicit_lib::test_inline_func_literal_false();
+      update_test_result_and_print_durations(result, durations);
+    }
+  }
+  {
+    test_result<NOEXCEPT_BENCHMARK_NUMBER_OF_INLINE_FUNC_CALLS> result(
+      "inline function calls, passing a volatile false argument");
+
+    for (int iteration_number = 0; iteration_number < number_of_iterations; ++iteration_number)
+    {
+      durations_type durations;
+      durations.duration_noexcept = noexcept_lib::test_inline_func_volatile_false();
+      durations.duration_implicit = implicit_lib::test_inline_func_volatile_false();
       update_test_result_and_print_durations(result, durations);
     }
   }


### PR DESCRIPTION
Distinguished between the performance of `inline_func(false)` and `inline_func(volatile_false)`.