### PR TITLE
Test a function that explicitly calls `std::terminate` on any exception

### DIFF
--- a/lib/explicitly_terminate_on_exception.cpp
+++ b/lib/explicitly_terminate_on_exception.cpp
@@ -1,0 +1,49 @@
+/*
+Copyright Niels Dekker, LKEB, Leiden University Medical Center
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "noexcept_benchmark.h"
+
+namespace
+{
+  inline void explicitly_terminate_if(const bool do_throw_exception) OPTIONAL_EXCEPTION_SPECIFIER
+  {
+    try
+    {
+      noexcept_benchmark::throw_exception_if(do_throw_exception);
+    }
+    catch (...)
+    {
+      std::terminate();
+    }
+  }
+}
+
+
+NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT
+double LIB_NAME::test_explicitly_terminate_on_exception()
+{
+  enum { number_of_func_calls = NOEXCEPT_BENCHMARK_NUMBER_OF_FUNC_CALLS_EXPLICITLY_TERMINATE };
+
+  return noexcept_benchmark::profile_func_call([]
+  {
+    volatile bool volatile_false{ noexcept_benchmark::get_false() };
+
+    for (int i = 0; i < number_of_func_calls; ++i)
+    {
+      explicitly_terminate_if(volatile_false);
+    }
+  });
+}

--- a/lib/exported_func.cpp
+++ b/lib/exported_func.cpp
@@ -18,7 +18,7 @@ limitations under the License.
 
 
 NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT
-void LIB_NAME::exported_func(bool do_throw_exception) OPTIONAL_EXCEPTION_SPECIFIER
+void LIB_NAME::exported_func(const bool do_throw_exception) OPTIONAL_EXCEPTION_SPECIFIER
 {
   noexcept_benchmark::throw_exception_if(do_throw_exception);
 }

--- a/lib/inline_func_test.cpp
+++ b/lib/inline_func_test.cpp
@@ -18,7 +18,7 @@ limitations under the License.
 
 namespace
 {
-  inline void inline_func(bool do_throw_exception) OPTIONAL_EXCEPTION_SPECIFIER
+  inline void inline_func(const bool do_throw_exception) OPTIONAL_EXCEPTION_SPECIFIER
   {
     noexcept_benchmark::throw_exception_if(do_throw_exception);
   }

--- a/lib/lib.h
+++ b/lib/lib.h
@@ -46,7 +46,7 @@ namespace NOEXCEPT_BENCHMARK_LIB_NAME
     int non_inline_get_data() const NOEXCEPT_BENCHMARK_EXCEPTION_SPECIFIER;
   };
 
-  NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT void exported_func(bool do_throw_exception) NOEXCEPT_BENCHMARK_EXCEPTION_SPECIFIER;
+  NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT void exported_func(const bool do_throw_exception) NOEXCEPT_BENCHMARK_EXCEPTION_SPECIFIER;
   NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT double catching_func();
   NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT double test_inc_and_dec();
   NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT double test_inline_func_literal_false();

--- a/lib/lib.h
+++ b/lib/lib.h
@@ -53,5 +53,6 @@ namespace NOEXCEPT_BENCHMARK_LIB_NAME
   NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT double test_inline_func_volatile_false();
   NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT double test_stack_unwinding();
   NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT double test_stack_unwinding_array();
+  NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT double test_explicitly_terminate_on_exception();
   NOEXCEPT_BENCHMARK_SHARED_LIB_EXPORT double test_vector_reserve();
 }

--- a/noexcept_benchmark.h
+++ b/noexcept_benchmark.h
@@ -68,6 +68,14 @@ limitations under the License.
 // Note: On Windows 10, x64, stack overflow occurred with N = 1280000
 #    define NOEXCEPT_BENCHMARK_STACK_UNWINDING_OBJECTS 1000000 // a million
 #  endif
+#  ifndef NOEXCEPT_BENCHMARK_NUMBER_OF_FUNC_CALLS_EXPLICITLY_TERMINATE
+#    ifdef _MSC_VER
+// This test appears to take much more time with MSVC (VS2017, VS2019), so do less iterations than with the other compilers.
+#      define NOEXCEPT_BENCHMARK_NUMBER_OF_FUNC_CALLS_EXPLICITLY_TERMINATE 200000000 // two hundred million
+#    else
+#      define NOEXCEPT_BENCHMARK_NUMBER_OF_FUNC_CALLS_EXPLICITLY_TERMINATE 2147483647 // INT32_MAX (about two billion)
+#    endif
+#  endif
 #  ifndef NOEXCEPT_BENCHMARK_INITIAL_VECTOR_SIZE
 #    define NOEXCEPT_BENCHMARK_INITIAL_VECTOR_SIZE 10000000 // ten million
 #  endif
@@ -79,6 +87,7 @@ limitations under the License.
 #  define NOEXCEPT_BENCHMARK_INC_AND_DEC_FUNC_CALLS 42
 #  define NOEXCEPT_BENCHMARK_STACK_UNWINDING_FUNC_CALLS 42
 #  define NOEXCEPT_BENCHMARK_STACK_UNWINDING_OBJECTS 42
+#  define NOEXCEPT_BENCHMARK_NUMBER_OF_FUNC_CALLS_EXPLICITLY_TERMINATE 42
 #  define NOEXCEPT_BENCHMARK_INITIAL_VECTOR_SIZE 42
 #endif
 

--- a/noexcept_benchmark_main.cpp
+++ b/noexcept_benchmark_main.cpp
@@ -427,6 +427,18 @@ int main()
     }
   }
   {
+    test_result<NOEXCEPT_BENCHMARK_NUMBER_OF_FUNC_CALLS_EXPLICITLY_TERMINATE> result(
+      "explicitly terminate on any exception");
+
+    for (int iteration_number = 0; iteration_number < number_of_iterations; ++iteration_number)
+    {
+      durations_type durations;
+      durations.duration_noexcept = noexcept_lib::test_explicitly_terminate_on_exception();
+      durations.duration_implicit = implicit_lib::test_explicitly_terminate_on_exception();
+      update_test_result_and_print_durations(result, durations);
+    }
+  }
+  {
     test_result<NOEXCEPT_BENCHMARK_INITIAL_VECTOR_SIZE> result(
       "std::vector<my_string> reserve");
 


### PR DESCRIPTION
Also added (top-level) `const` keywords to `do_throw_exception` function parameters.