### PR TITLE
Add link to the book "Embracing Modern C++ Safely", add note to license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,7 @@
+License for the `noexcept` benchmark from https://github.com/N-Dekker/noexcept_benchmark
+which is maintained by Niels Dekker (LKEB, Leiden University Medical Center)
+
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ Related to:
 [Stack Overflow - noexcept, stack unwinding and performance](https://stackoverflow.com/questions/26079903/noexcept-stack-unwinding-and-performance)
 
 [Andrzej's C++ blog - noexcept — what for?](https://akrzemi1.wordpress.com/2014/04/24/noexcept-what-for/)
+
+[John Lakos, Vittorio Romeo, Rostislav Khlebnikov, Alisdair Meredith - Embracing Modern C++ Safely](https://emcpps.com) section 3.1 "The noexcept Function Specification"


### PR DESCRIPTION
The Bibliography section of "Embracing Modern C++ Safely" (first edition) explicitly mentions https://github.com/N-Dekker/noexcept_benchmark/blob/main/LICENSE so it appears worth clarifying this file somewhat.